### PR TITLE
Add path2 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "async": "^0.9.0",
     "lodash": "^2.4.1",
     "mkdirp": "^0.5.0",
+    "path2": "^0.1.0",
     "stream-line-wrapper": "^0.1.1"
   },
   "peerDependencies": {

--- a/tasks/deploy/publish.js
+++ b/tasks/deploy/publish.js
@@ -3,7 +3,7 @@
  */
 
 var async = require('async');
-var path = require('path');
+var path = require('path2/posix');
 
 /**
  * Publish task.

--- a/tasks/deploy/update.js
+++ b/tasks/deploy/update.js
@@ -3,7 +3,7 @@
  */
 
 var async = require('async');
-var path = require('path');
+var path = require('path2/posix');
 
 /**
  * Update task.

--- a/tasks/rollback/init.js
+++ b/tasks/rollback/init.js
@@ -3,7 +3,7 @@
  */
 
 var async = require('async');
-var path = require('path');
+var path = require('path2/posix');
 var _ = require('lodash');
 
 /**


### PR DESCRIPTION
Fixes the issue for directories separator which are not correct when the remote server and the local machine have a different OS (/ for Linux and \ for Windows).