### PR TITLE
Publishing with a relative symlink

### DIFF
--- a/tasks/deploy/publish.js
+++ b/tasks/deploy/publish.js
@@ -32,8 +32,9 @@ module.exports = function (grunt) {
       grunt.log.writeln('Publishing release "%s"', grunt.shipit.releasePath);
 
       grunt.shipit.currentPath = path.join(grunt.shipit.config.deployTo, 'current');
+      var relativeReleasePath = path.join('releases', grunt.shipit.releaseDirname);
 
-      grunt.shipit.remote('ln -nfs ' + grunt.shipit.releasePath + ' ' + grunt.shipit.currentPath,
+      grunt.shipit.remote('cd ' + grunt.shipit.config.deployTo + ' && ln -nfs ' + relativeReleasePath + ' current',
         function (err) {
           if (err) return cb(err);
           grunt.log.oklns('Release published.');

--- a/test/unit/tasks/deploy/publish.js
+++ b/test/unit/tasks/deploy/publish.js
@@ -23,6 +23,7 @@ describe('deploy:publish task', function () {
     });
 
     shipit.releasePath = '/remote/deploy/releases/20141704123138';
+    shipit.releaseDirname = '20141704123138';
 
     sinon.stub(shipit, 'remote').yields();
   });
@@ -36,8 +37,7 @@ describe('deploy:publish task', function () {
     runTask('deploy:publish', function (err) {
       if (err) return done(err);
       expect(shipit.currentPath).to.equal('/remote/deploy/current');
-      expect(shipit.remote).to.be.calledWith('ln -nfs /remote/deploy/releases/20141704123138 ' +
-      '/remote/deploy/current');
+      expect(shipit.remote).to.be.calledWith('cd /remote/deploy && ln -nfs releases/20141704123138 current');
       done();
     });
   });


### PR DESCRIPTION
Changes the publishing symlink to be relative instead of absolute. This update fixes publishing which doesn't work when the *deployTo* option is a relative path.

Relative links are better if the directories they target are moved or mounted elsewhere for example.